### PR TITLE
feat: support for nested paths in ProcessAttr

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: pretty-format-json
@@ -18,21 +18,21 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.14
+    rev: v0.8.0
     hooks:
       - id: ruff-format
       - id: ruff
         args: [ --fix, --unsafe-fixes ]
 
   - repo: https://github.com/pycqa/flake8
-    rev: '7.0.0'
+    rev: '7.1.1'
     hooks:
       - id: flake8
         args: ["--config=pyproject.toml"]
         additional_dependencies: ["flake8-pyproject", "wemake-python-styleguide"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.8.0'
+    rev: 'v1.13.0'
     hooks:
       - id: mypy
         additional_dependencies: [ "no_implicit_optional" ]

--- a/logic_processes_layer/extensions/mappers.py
+++ b/logic_processes_layer/extensions/mappers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 __all__ = ("InitMapper", "ProcessAttr")
 
 import dataclasses
+from operator import attrgetter
 import typing
 
 
@@ -17,9 +18,8 @@ class ProcessAttr:
     from_context: bool = dataclasses.field(default=False)
 
     def get_value(self, context: typing.Any) -> typing.Any:  # noqa: ANN401
-        if self.from_context:
-            return getattr(context, self.attr_name)
-        return getattr(context.process, self.attr_name)
+        source = (context.process, context)[self.from_context]
+        return attrgetter(self.attr_name)(source)
 
 
 class InitMapper:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "logic_processes_layer"
-version = "1.1.3"
+version = "1.1.4"
 requires-python = ">=3.8"
 description = "Abstractions for create business logic"
 readme = "README.md"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,13 +1,13 @@
-
 force-exclude = true
-ignore-init-module-imports = true
-select = ["ALL"]
 line-length = 120
 output-format = "grouped"
 target-version = "py38"
+
+[lint]
+select = ["ALL"]
 fixable = ["ALL"]
 ignore = [
-    'ANN002', 'ANN003', 'ANN101',
+    'ANN002', 'ANN003',
     'COM812',
     'D100', 'D101', 'D103', 'D102', 'D104', 'D105', 'D106', "D107", "D400",
     'D203', 'D205',
@@ -15,21 +15,22 @@ ignore = [
     'ISC001',
     "TD001", "TID252",
 ]
-external = ["WPS221", "WPS432", "WPS529", "WPS601",]
 
-[per-file-ignores]
+external = ["WPS221", "WPS432", "WPS529", "WPS601","WPS428"]
+
+[lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]
 "tests/test_*.py" = ["S101", "S311"]
 
-[flake8-annotations]
+[lint.flake8-annotations]
 mypy-init-return = true
 ignore-fully-untyped = true
 allow-star-arg-any = true
 
-[pydocstyle]
+[lint.pydocstyle]
 convention = "pep257"
 
-[isort]
+[lint.isort]
 force-single-line = false
 force-wrap-aliases = true
 force-sort-within-sections = true

--- a/tests/examples/processors/multy_process.py
+++ b/tests/examples/processors/multy_process.py
@@ -6,7 +6,7 @@ from logic_processes_layer import BaseProcessor, BaseProcessorContext
 from logic_processes_layer.extensions import InitMapper, ProcessAsSubprocess, ProcessAttr
 from logic_processes_layer.processors.base import ResultsT
 
-from ..sub_processors import SympleSubprocessor
+from ..sub_processors import SimpleSubprocessor
 
 
 class CompositionContext(BaseProcessorContext["ProcessComposition"]):
@@ -38,7 +38,7 @@ class ProcessComposition(BaseProcessor[CompositionContext, ResultsT]):
     context_cls = CompositionContext
 
     pre_run = (
-        SympleSubprocessor(),
+        SimpleSubprocessor(),
         SubProc(
             process_cls=ProcessWithInitalData,
             init_mapper=InitMapper(1, 2),

--- a/tests/examples/processors/process_with_nested_attrs.py
+++ b/tests/examples/processors/process_with_nested_attrs.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from logic_processes_layer import BaseProcessor
+from logic_processes_layer.extensions import InitMapper, ProcessAttr
+
+from .multy_process import ProcessWithInitalData, SubProc
+
+
+if TYPE_CHECKING:
+    from ..protocols.supports_get_attribute import SupportsGetAttribute
+
+
+@dataclasses.dataclass
+class ProcessWithNestedAttributes(BaseProcessor):
+    attr: SupportsGetAttribute
+
+    post_run = (
+        SubProc(
+            process_cls=ProcessWithInitalData,
+            init_mapper=InitMapper(
+                some_attr_one=ProcessAttr("attr.some_attr_one"),
+                some_attr_two=ProcessAttr("attr.some_attr_two"),
+            ),
+        ),
+    )
+
+    def run(self):
+        return self.attr.some_attr_one + self.attr.some_attr_two

--- a/tests/examples/processors/simple.py
+++ b/tests/examples/processors/simple.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 
-__all__ = ("SympleProcessor",)
+__all__ = ("SimpleProcessor",)
 
 from logic_processes_layer import BaseProcessor
 
 
-class SympleProcessor(BaseProcessor):
+class SimpleProcessor(BaseProcessor):
     def run(self):
         return self.__class__.__name__

--- a/tests/examples/protocols/__init__.py
+++ b/tests/examples/protocols/__init__.py
@@ -1,0 +1,1 @@
+from .supports_get_attribute import *

--- a/tests/examples/protocols/supports_get_attribute.py
+++ b/tests/examples/protocols/supports_get_attribute.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+
+__all__ = ("SupportsGetAttribute",)
+
+import typing
+
+
+class SupportsGetAttribute(typing.Protocol):
+    some_attr_one: int
+    some_attr_two: int
+
+    def __getattribute__(self, name: str) -> typing.Any:  # noqa: ANN401
+        ...  # noqa: WPS428

--- a/tests/examples/sub_processors/__init__.py
+++ b/tests/examples/sub_processors/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-from .symple import *
+from .simple import *

--- a/tests/examples/sub_processors/simple.py
+++ b/tests/examples/sub_processors/simple.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from logic_processes_layer import BaseSubprocessor
 
 
-__all__ = ("SympleSubprocessor",)
+__all__ = ("SimpleSubprocessor",)
 
 
-class SympleSubprocessor(BaseSubprocessor):
+class SimpleSubprocessor(BaseSubprocessor):
     def __call__(self):
         return self.__class__.__name__

--- a/tests/test_process_composition.py
+++ b/tests/test_process_composition.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 
-from tests.examples.processors.mylty_process import ProcessComposition
+from tests.examples.processors.multy_process import ProcessComposition
 
 
 class TestProcessComposition:
@@ -10,14 +10,14 @@ class TestProcessComposition:
         self.start_data = (random.randint(1, 10), random.randint(1, 10))
         self.process: ProcessComposition = ProcessComposition(*self.start_data)
         self.expected_result = {
-            "pre_run": ("SympleSubprocessor", 3, sum(self.start_data)),
+            "pre_run": ("SimpleSubprocessor", 3, sum(self.start_data)),
             "post_run": (333, 333),
         }
 
     def check_state(self, state_name):
         proc_state_instances = getattr(self.process, state_name)
         for idx, state_instance in enumerate(proc_state_instances):
-            assert state_instance.call_result == self.expected_result[state_name][idx], (state_name, idx)
+            assert state_instance.call_result == self.expected_result[state_name][idx]
 
     def test_process_composition(self):
         self.process()

--- a/tests/test_process_with_nested_attrs.py
+++ b/tests/test_process_with_nested_attrs.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import dataclasses
+import random
+
+from .examples.processors.process_with_nested_attrs import ProcessWithNestedAttributes
+
+
+@dataclasses.dataclass
+class TestData:
+    some_attr_one: int = dataclasses.field(default_factory=lambda: random.randint(1, 100))
+    some_attr_two: int = dataclasses.field(default_factory=lambda: random.randint(1, 100))
+
+
+class TestProcessWithNestedAttributes:
+    def setup_method(self):
+        self.start_data = TestData()
+        self.process: ProcessWithNestedAttributes = ProcessWithNestedAttributes(self.start_data)
+        self.expected_result = {
+            "post_run": (self.start_data.some_attr_one, self.start_data.some_attr_two),
+        }
+
+    def check_state(self, state_name):
+        proc_state_instances = getattr(self.process, state_name)
+        for idx, state_instance in enumerate(proc_state_instances):
+            assert state_instance.call_result == sum(self.expected_result[state_name]), (state_name, idx)
+
+    def test_process_composition(self):
+        self.process()
+
+        for state_name in self.expected_result:
+            self.check_state(state_name)

--- a/tests/test_processor_with_subprocessors.py
+++ b/tests/test_processor_with_subprocessors.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
-from tests.examples.processors.symple import SympleProcessor
-from tests.examples.sub_processors import SympleSubprocessor
+from tests.examples.processors.simple import SimpleProcessor
+from tests.examples.sub_processors import SimpleSubprocessor
 
 
-def make_symple_subprocessor(cls_name):
-    return type(cls_name, (SympleSubprocessor,), {})
+def make_simple_subprocessor(cls_name):
+    return type(cls_name, (SimpleSubprocessor,), {})
 
 
-class ProcessorWithSubprocess(SympleProcessor):
-    pre_run = tuple(make_symple_subprocessor(f"Subprocessor{idx}")() for idx in range(2))  # noqa: WPS221
-    post_run = tuple(make_symple_subprocessor(f"Subprocessor{idx}")() for idx in range(2, 5))  # noqa: WPS221
+class ProcessorWithSubprocess(SimpleProcessor):
+    pre_run = tuple(make_simple_subprocessor(f"Subprocessor{idx}")() for idx in range(2))  # noqa: WPS221
+    post_run = tuple(make_simple_subprocessor(f"Subprocessor{idx}")() for idx in range(2, 5))  # noqa: WPS221
 
 
 class TestProcessorWithSubprocess:

--- a/tests/test_simple_processor.py
+++ b/tests/test_simple_processor.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from tests.examples.processors.symple import SympleProcessor
+from tests.examples.processors.simple import SimpleProcessor
 
 
-class TestSympleProcessor:
+class TestSimpleProcessor:
     def setup_method(self):
-        self.processor = SympleProcessor()
+        self.processor = SimpleProcessor()
 
     def test_run(self):
         assert self.processor.run() == self.processor.__class__.__name__

--- a/tests/test_sub_processor.py
+++ b/tests/test_sub_processor.py
@@ -4,13 +4,13 @@ from unittest.mock import Mock
 
 from logic_processes_layer import BaseProcessor, BaseProcessorContext
 
-from .examples.sub_processors import SympleSubprocessor
+from .examples.sub_processors import SimpleSubprocessor
 
 
-class TestSympleSubprocessor:
+class TestSimpleSubprocessor:
     def setup_method(self):
         self.context = BaseProcessorContext(process=Mock(spec=BaseProcessor))
-        self.subprocessor = SympleSubprocessor()
+        self.subprocessor = SimpleSubprocessor()
         self.subprocessor.context = self.context
 
     def test_call(self):


### PR DESCRIPTION
- Added support to use nested paths in ProcessAttr
- Added a test case for nested path functionality
- Added a protocol for type checking with nested attributes
- Updated pre-commit hooks
- Updated version in pyproject.toml
- Fixed typos in module and class names
- Adjusted ruff configuration
- Deleted ignore-init-module-imports. Deprecated
- Deleted ANN101. Deprecated